### PR TITLE
Select MarqueeLabel import based on build system

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
+github "cbpowell/MarqueeLabel" "3.0.5"
 github "SnapKit/SnapKit" "3.2.0"
-github "cbpowell/MarqueeLabel" "3.0.3"

--- a/NotificationBanner.xcodeproj/project.pbxproj
+++ b/NotificationBanner.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		823255B41EB87313006F95C3 /* StatusBarNotificationBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 823255A41EB87313006F95C3 /* StatusBarNotificationBanner.swift */; };
 		823255B61EB87313006F95C3 /* NotificationBanner.h in Headers */ = {isa = PBXBuildFile; fileRef = 823255A71EB87313006F95C3 /* NotificationBanner.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		823255B91EB8736D006F95C3 /* Cartfile in Resources */ = {isa = PBXBuildFile; fileRef = 823255B81EB8736D006F95C3 /* Cartfile */; };
+		EA9A178A1EC75DE000CF2261 /* MarqueeLabelSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA9A17891EC75DE000CF2261 /* MarqueeLabelSwift.framework */; };
+		EA9A178C1EC75DE400CF2261 /* SnapKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EA9A178B1EC75DE400CF2261 /* SnapKit.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -30,6 +32,8 @@
 		823255A71EB87313006F95C3 /* NotificationBanner.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NotificationBanner.h; sourceTree = "<group>"; };
 		823255B81EB8736D006F95C3 /* Cartfile */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Cartfile; sourceTree = "<group>"; };
 		823255BB1EB87CB7006F95C3 /* Cartfile.resolved */ = {isa = PBXFileReference; lastKnownFileType = text; path = Cartfile.resolved; sourceTree = "<group>"; };
+		EA9A17891EC75DE000CF2261 /* MarqueeLabelSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = MarqueeLabelSwift.framework; path = Carthage/Build/iOS/MarqueeLabelSwift.framework; sourceTree = "<group>"; };
+		EA9A178B1EC75DE400CF2261 /* SnapKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SnapKit.framework; path = Carthage/Build/iOS/SnapKit.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -37,6 +41,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EA9A178A1EC75DE000CF2261 /* MarqueeLabelSwift.framework in Frameworks */,
+				EA9A178C1EC75DE400CF2261 /* SnapKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -49,6 +55,7 @@
 				823255B71EB8735E006F95C3 /* Root Files */,
 				8232558D1EB872AB006F95C3 /* NotificationBanner */,
 				8232558C1EB872AB006F95C3 /* Products */,
+				EA9A17881EC75DE000CF2261 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -99,6 +106,15 @@
 				823255BB1EB87CB7006F95C3 /* Cartfile.resolved */,
 			);
 			name = "Root Files";
+			sourceTree = "<group>";
+		};
+		EA9A17881EC75DE000CF2261 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				EA9A178B1EC75DE400CF2261 /* SnapKit.framework */,
+				EA9A17891EC75DE000CF2261 /* MarqueeLabelSwift.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */

--- a/NotificationBanner.xcodeproj/project.pbxproj
+++ b/NotificationBanner.xcodeproj/project.pbxproj
@@ -326,6 +326,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				OTHER_SWIFT_FLAGS = "-DCARTHAGE_CONFIG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dh.NotificationBanner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -349,6 +350,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				OTHER_SWIFT_FLAGS = "-DCARTHAGE_CONFIG";
 				PRODUCT_BUNDLE_IDENTIFIER = com.dh.NotificationBanner;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/NotificationBanner/Classes/BaseNotificationBanner.swift
+++ b/NotificationBanner/Classes/BaseNotificationBanner.swift
@@ -17,7 +17,11 @@
  */
 
 import UIKit
-import MarqueeLabelSwift
+#if CARTHAGE_CONFIG
+    import MarqueeLabelSwift
+#else
+    import MarqueeLabel
+#endif
 
 public class BaseNotificationBanner: UIView {
     

--- a/NotificationBanner/Classes/NotificationBanner.swift
+++ b/NotificationBanner/Classes/NotificationBanner.swift
@@ -18,7 +18,11 @@
 
 import UIKit
 import SnapKit
-import MarqueeLabelSwift
+#if CARTHAGE_CONFIG
+    import MarqueeLabelSwift
+#else
+    import MarqueeLabel
+#endif
 
 public class NotificationBanner: BaseNotificationBanner {
     

--- a/NotificationBanner/Classes/StatusBarNotificationBanner.swift
+++ b/NotificationBanner/Classes/StatusBarNotificationBanner.swift
@@ -17,7 +17,11 @@
  */
 
 import UIKit
-import MarqueeLabelSwift
+#if CARTHAGE_CONFIG
+    import MarqueeLabelSwift
+#else
+    import MarqueeLabel
+#endif
 
 public class StatusBarNotificationBanner: BaseNotificationBanner {
     


### PR DESCRIPTION
Adds a custom Swift complier flag, allowing a if/else statement to pick `import MarqueeLabel` vs `import MarqueeLabelSwift` to work around Cocoapods/Carthage compatibility issues.

See https://github.com/cbpowell/MarqueeLabel/issues/181.